### PR TITLE
Make direct IP persistent

### DIFF
--- a/Source/Client/MultiplayerMod.cs
+++ b/Source/Client/MultiplayerMod.cs
@@ -176,6 +176,7 @@ namespace Multiplayer.Client
         public int autosaveSlots = 5;
         public bool aggressiveTicking;
         public bool showDevInfo;
+        public string serverAddress;
 
         public override void ExposeData()
         {
@@ -186,6 +187,7 @@ namespace Multiplayer.Client
             Scribe_Values.Look(ref autosaveSlots, "autosaveSlots", 5);
             Scribe_Values.Look(ref aggressiveTicking, "aggressiveTicking");
             Scribe_Values.Look(ref showDevInfo, "showDevInfo");
+            Scribe_Values.Look(ref serverAddress, "serverAddress", "127.0.0.1");
         }
     }
 }

--- a/Source/Client/Windows/ServerBrowser.cs
+++ b/Source/Client/Windows/ServerBrowser.cs
@@ -505,17 +505,15 @@ namespace Multiplayer.Client
             Widgets.EndScrollView();
         }
 
-        private string ipBuffer = "127.0.0.1";
-
         private void DrawDirect(Rect inRect)
         {
-            ipBuffer = Widgets.TextField(new Rect(inRect.center.x - 200 / 2, 15f, 200, 35f), ipBuffer);
+            MultiplayerMod.settings.serverAddress = Widgets.TextField(new Rect(inRect.center.x - 200 / 2, 15f, 200, 35f), MultiplayerMod.settings.serverAddress);
 
             const float btnWidth = 115f;
 
             if (Widgets.ButtonText(new Rect(inRect.center.x - btnWidth / 2, 60f, btnWidth, 35f), "MpConnectButton".Translate()))
             {
-                string ip = ipBuffer.Trim();
+                string ip = MultiplayerMod.settings.serverAddress.Trim();
 
                 int port = MultiplayerServer.DefaultPort;
                 string[] ipport = ip.Split(':');

--- a/Source/Client/Windows/ServerBrowser.cs
+++ b/Source/Client/Windows/ServerBrowser.cs
@@ -531,6 +531,7 @@ namespace Multiplayer.Client
                     Log.Message("Connecting directly");
 
                     Find.WindowStack.Add(new ConnectingWindow(address, port) { returnToServerBrowser = true });
+                    MultiplayerMod.settings.Write();
                     Close(false);
                 }
             }


### PR DESCRIPTION
Partially fixes #26: the IP is saved until the game is restarted.