### PR TITLE
Fix Unix/Windows hash computation inconsistencies

### DIFF
--- a/Source/Client/Multiplayer.cs
+++ b/Source/Client/Multiplayer.cs
@@ -429,7 +429,7 @@ namespace Multiplayer.Client
                 if (IgnoredVanillaDefTypes.Contains(defType)) continue;
 
                 var defs = GenDefDatabase.GetAllDefsInDatabaseForDef(defType);
-                dict.Add(defType.Name, GetDefInfo(defs, d => GenText.StableStringHash(d.defName)));
+                dict.Add(defType.Name, GetDefInfo(defs.OrderBy(d => d.defName), d => GenText.StableStringHash(d.defName)));
             }
 
             return dict;


### PR DESCRIPTION
Fixes Linux players not being able to play with Windows players because of different order of definitions in memory.
This issue occurs with some mods that use specific filenames for defs (EPOE, for example), and is caused by differences in file sorting for filesystems with different casing (i.e. `Recipe_BasicProsthetics.xml` is loaded before `Recipe_BasicProstheticWorkbench.xml` on case-insensitive _NTFS_, but not on case-sensitive _ext_)